### PR TITLE
Update repository for pentaho builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 pdi-google-spreadsheet-plugin
 =============================
 
+**NOTE**: This is forked from [GlobalTechnology](https://github.com/GlobalTechnology/pdi-google-spreadsheet-plugin) due to apparent inactivity. Should the upstream repo merge changes and be maintained, this repo will be dropped. 
+
 Plugin for Pentaho Data Integration(Kettle) allowing reading and writing of Google Spreadsheets.
 
 Limitations

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <repositories>
         <repository>
             <id>pentaho-releases</id>
-            <url>http://repository.pentaho.org/artifactory/repo/</url>
+            <url>http://nexus.pentaho.org/content/groups/omni/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The repository.pentaho.org repo is offline, and has been updated to nexus.pentaho.org. This PR fixes the build and restores it to a buildable state.